### PR TITLE
Installing and configuring prettier

### DIFF
--- a/projects/physics/.prettierrc
+++ b/projects/physics/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": true
+}

--- a/projects/physics/Makefile
+++ b/projects/physics/Makefile
@@ -1,0 +1,7 @@
+# Remove make's default rules.
+.SUFFIXES:
+
+SHELL := bash -O globstar
+
+pretty:
+	npx prettier --write **/*.js

--- a/projects/physics/package-lock.json
+++ b/projects/physics/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "dependencies": {
         "express": "^4.18.2"
+      },
+      "devDependencies": {
+        "prettier": "^2.8.2"
       }
     },
     "node_modules/accepts": {
@@ -399,6 +402,21 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/prettier": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -879,6 +897,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "prettier": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/projects/physics/package.json
+++ b/projects/physics/package.json
@@ -2,5 +2,8 @@
   "type": "module",
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "prettier": "^2.8.2"
   }
 }


### PR DESCRIPTION
`prettier` is a tool that formats Javascript (and a bunch of other things like HTML and CSS) more dramatically than VS Codes "Format document" command. To finish setting it up, open a terminal in `projects/physics` and run `npm install` (or `npm i`).

It's a good idea to use a code formatter for two reasons:

1. It minimizing the differences you have to look at when reviewing changes by getting rid of irrelevant differences like whitespace changes and missing semicolons.
2. On group projects it standardizes formatting so idiosyncrasies of formatting style don't cause needless diffs and/or conflict. Just go with how the code formatter does things and everyone can get on with their lives.

I've set things up so you can run `prettier` via another tool called `make` which is controlled by the file `Makefile`. Basically in the terminal, when you're in the `projects/physics` directory you can type `make` or `make pretty` and it will run `prettier` on all the `.js` files below the directory (ignoring files that are ignored by `.gitignore` which is good because we don't want to reformat the `.js` files under `node_modules`.

As a side note, notice how I named this branch: `gigamonkey/prettier`. That's a common convention on group projects, to prefix the branch name with your username. That makes it easy to tell what branches belong to whom, makes sure there aren't conflicts over branch names, and makes it easy to list just your own branches in the command line tool. You should adopt that convention on this project to make each others' (and my) lives easier.